### PR TITLE
Add introspective memory update

### DIFF
--- a/src/neural_memory.py
+++ b/src/neural_memory.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 from transformers import AutoTokenizer
 from src.modeling_mplus import MPlus
 
@@ -34,3 +35,42 @@ class NeuralMemory:
             self.tokenizer(ctx, return_tensors='pt', add_special_tokens=False).input_ids.to(self.model.device),
             update_memory=True
         )
+
+    def evaluate_and_update(self, user_input: str, response: str, threshold: float = 0.7) -> float:
+        """Assess the certainty of ``response`` given ``user_input`` and update long-term memory
+        when the certainty is above ``threshold``.
+
+        The certainty estimate roughly follows the idea of Intuitor by using the
+        model's own likelihood over the generated tokens as an introspective
+        signal.
+
+        Args:
+            user_input: Prompt from the user.
+            response: Model generated response to ``user_input``.
+            threshold: Value between 0 and 1. Memory is updated when the
+                certainty is greater or equal to this value.
+
+        Returns:
+            The computed certainty score.
+        """
+
+        # Encode the full conversation and locate the response tokens.
+        input_ids = self.tokenizer(user_input + response, return_tensors="pt", add_special_tokens=False).input_ids.to(self.model.device)
+        prompt_ids = self.tokenizer(user_input, return_tensors="pt", add_special_tokens=False).input_ids.to(self.model.device)
+
+        response_length = input_ids.shape[1] - prompt_ids.shape[1]
+        if response_length <= 0:
+            return 0.0
+
+        with torch.no_grad():
+            outputs = self.model(input_ids[:, :-1], return_dict=True)
+            logits = outputs.logits[:, -response_length:, :]
+
+        target = input_ids[:, -response_length:]
+        loss = F.cross_entropy(logits.reshape(-1, logits.size(-1)), target.reshape(-1), reduction="mean")
+        certainty = torch.sigmoid(-loss).item()
+
+        if certainty >= threshold:
+            self.persist(user_input + " " + response)
+
+        return certainty


### PR DESCRIPTION
## Summary
- introspective memory evaluation method to NeuralMemory
- update long-term memory when the model is confident

## Testing
- `python -m py_compile src/neural_memory.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*