### PR TITLE
Add introspective surprise check

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ ctx = "Last week, John had a wonderful picnic with David. During their conversat
 model.inject_memory(tokenizer(ctx, return_tensors='pt', add_special_tokens=False).input_ids.cuda(), update_memory=True)
 ```
 
+The helper class ``NeuralMemory`` can introspect conversations and persist only
+the surprising parts. After generating a response, call
+``evaluate_and_update`` with the user input and model response:
+
+```python
+nm = NeuralMemory()
+prompt = "Question: What fruits does David like?"
+response = nm.query(prompt)
+surprise = nm.evaluate_and_update(prompt, response, threshold=0.5)
+print(f"Surprise: {surprise:.2f}")
+```
+
 Then for chat model, use the following template: 
 ```python
 # Generation


### PR DESCRIPTION
## Summary
- introspective update now measures surprise and persists input when it's high
- document usage of `evaluate_and_update`

## Testing
- `python -m py_compile src/neural_memory.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sklearn')*